### PR TITLE
Mobile Menu No Scrolling Fix

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -492,6 +492,7 @@ a.small_logo img {
 	transition: all .3s linear;
 	opacity: 0;
 	z-index: -100;
+	overflow-y: scroll;
 }
 
 .mobile-offcanvas.open {


### PR DESCRIPTION
Per #13, the mobile menu doesn't scroll when the contents go past
the container. This is now fixed.