### PR TITLE
Add row class to view wrapper

### DIFF
--- a/templates/views/views-view.html.twig
+++ b/templates/views/views-view.html.twig
@@ -35,6 +35,7 @@
 {%
   set classes = [
     dom_id ? 'js-view-dom-id-' ~ dom_id,
+    'row',
   ]
 %}
 <div{{ attributes.addClass(classes) }}>


### PR DESCRIPTION
Add row class to view wrapper, allowing the use of col classes in the row class field of a view display format settings.